### PR TITLE
Fix issue#18 (partiallY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The datasheet for the eeprom can be found [here](http://dlnmh9ip6v2uc.cloudfront
     ```
     Starting transfer test
     Writing DONE, event is 8
-    Writing DONE (slave is ready), event is 8
+    Slave is ready for reading, event is 8
+    Reading DONE, event is 8
     Read data match with written data, event is 8
     **** Test done ****
     ```

--- a/source/i2c_master_eeprom_asynch.cpp
+++ b/source/i2c_master_eeprom_asynch.cpp
@@ -48,8 +48,7 @@ public:
     }
 
 private:
-    void write_data_complete(Buffer tx_buffer, Buffer rx_buffer, int narg)
-    {
+    void write_data_complete(Buffer tx_buffer, Buffer rx_buffer, int narg) {
         (void)tx_buffer;
         (void)rx_buffer;
         printf("Writing DONE, event is %d\r\n", narg);


### PR DESCRIPTION
I added a callback to wait for slave to ack (we can add later the timer for no slave found, to terminate never-ending waiting).

This fixes a problem for one of my shields, the another one from niklas still fails with the last 2 bytes different.
Once approved, this can be merged as a fix and the issue would stay open to track the data mismatch.

@niklas-arm @bogdanm

Update: I tested 4 eeproms, 2 failed, 2 passed.