### PR TITLE
Changed serial speed setting

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
   ],
   "extraIncludes": [],
   "dependencies": {
-    "mbed-drivers": "~0.11.0"
+    "mbed-drivers": "~0.12.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/source/i2c_master_eeprom_asynch.cpp
+++ b/source/i2c_master_eeprom_asynch.cpp
@@ -126,8 +126,7 @@ private:
 void app_start(int, char*[]) {
     static I2CTest test;
     // set 115200 baud rate for stdout
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     Scheduler::postCallback(mbed::util::FunctionPointer0<void>(&test, &I2CTest::start).bind());
 }
 
@@ -135,8 +134,7 @@ void app_start(int, char*[]) {
 
 void app_start(int, char*[]) {
     // set 115200 baud rate for stdout
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
+    get_stdio_serial().baud(115200);
     printf("The target does not support I2C asynch API.\r\n");
 }
 #endif


### PR DESCRIPTION
The way to set the serial speed changed starting with mbed-drivers
0.12.0. This commit updates the code to use the new way of setting
the speed.