### PR TITLE
Update API to I2C fluent API

### DIFF
--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
   ],
   "extraIncludes": [],
   "dependencies": {
-    "mbed-drivers": "~0.12.0"
+    "mbed-drivers": "^1.1.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/source/i2c_master_eeprom_asynch.cpp
+++ b/source/i2c_master_eeprom_asynch.cpp
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 #include <stdio.h>
+#include <stdint.h>
 
 #include "mbed-drivers/mbed.h"
 #include "minar/minar.h"
 #include "core-util/Event.h"
-
+#include "mbed-drivers/v2/I2C.hpp"
 #if DEVICE_I2C && DEVICE_I2C_ASYNCH
 
 #if !defined(YOTTA_CFG_HARDWARE_TEST_PINS_I2C_SDA) || !defined(YOTTA_CFG_HARDWARE_TEST_PINS_I2C_SCL)
@@ -27,6 +28,7 @@
 #endif
 
 using namespace minar;
+using namespace mbed::drivers;
 
 const char pattern[] = {0x66, (char)~0x66, 0x00, 0xFF, 0xA5, 0x5A, 0xF0, 0x0F, 0x33, 0xAA, 0xF0, 0x0F, 0xFF};
 const int eeprom_address = 0xA0;
@@ -45,7 +47,10 @@ public:
         init_rx_buffer();
         set_eeprom_access_address(0x100);
         set_tx_pattern();
-        i2c.transfer(eeprom_address, tx_data, sizeof(tx_data), NULL, 0, I2C::event_callback_t(this, &I2CTest::write_data_complete), I2C_EVENT_ALL, false);
+        i2c.transfer_to(eeprom_address)
+            .tx(tx_data, sizeof(tx_data))
+            .on(I2C_EVENT_ALL, v2::I2C::event_callback_t(this, &I2CTest::write_data_complete))
+            .apply();
     }
 
 private:
@@ -54,44 +59,53 @@ private:
         tx_data[1] = address & 0xFF;        // low byte address
     }
 
-    void write_data_complete(Buffer tx_buffer, Buffer rx_buffer, int narg) {
-        (void)tx_buffer;
-        (void)rx_buffer;
-        printf("Writing DONE, event is %d\r\n", narg);
-        i2c.transfer(eeprom_address, NULL, 0, NULL, 0, I2C::event_callback_t(this, &I2CTest::slave_ready), I2C_EVENT_ALL, false);
+    void write_data_complete(v2::I2CTransaction *t, uint32_t narg) {
+        (void)t;
+        printf("Writing DONE, event is %lu\r\n", narg);
+        i2c.transfer_to(eeprom_address)
+            .tx(nullptr,0)
+            .on(I2C_EVENT_ALL, v2::I2C::event_callback_t(this, &I2CTest::slave_ready))
+            .apply();
     }
 
-    void slave_ready(Buffer tx_buffer, Buffer rx_buffer, int narg) {
-        (void)tx_buffer;
-        (void)rx_buffer;
+    void slave_ready(v2::I2CTransaction *t, uint32_t narg) {
+        (void)t;
         if (narg == I2C_EVENT_TRANSFER_COMPLETE) {
             // slave ack, send more data
-            i2c.transfer(eeprom_address, NULL, 0, NULL, 0, I2C::event_callback_t(this, &I2CTest::read_data_cb), I2C_EVENT_ALL, false);
+            i2c.transfer_to(eeprom_address)
+                .tx(nullptr,0)
+                .on(I2C_EVENT_ALL, v2::I2C::event_callback_t(this, &I2CTest::read_data_cb))
+                .apply();
         } else {
             // slave not ready, retry
-            i2c.transfer(eeprom_address, NULL, 0, NULL, 0, I2C::event_callback_t(this, &I2CTest::slave_ready), I2C_EVENT_ALL, false);
+            i2c.transfer_to(eeprom_address)
+                .tx(nullptr,0)
+                .on(I2C_EVENT_ALL, v2::I2C::event_callback_t(this, &I2CTest::slave_ready))
+                .apply();
         }
     }
 
-    void read_data_cb(Buffer tx_buffer, Buffer rx_buffer, int narg) {
-        (void)tx_buffer;
-        (void)rx_buffer;
-        printf("Slave is ready for reading, event is %d\r\n", narg);
+    void read_data_cb(v2::I2CTransaction *t, uint32_t narg) {
+        (void)t;
+        printf("Slave is ready for reading, event is %lu\r\n", narg);
         set_eeprom_access_address(0x100);
-        i2c.transfer(eeprom_address, tx_data, 2, rx_data, sizeof(rx_data), I2C::event_callback_t(this, &I2CTest::compare_data_cb), I2C_EVENT_ALL, false);
+        i2c.transfer_to(eeprom_address)
+            .tx(tx_data,2)
+            .rx(rx_data, sizeof(rx_data))
+            .on(I2C_EVENT_ALL, v2::I2C::event_callback_t(this, &I2CTest::compare_data_cb))
+            .apply();
     }
 
-    void compare_data_cb(Buffer tx_buffer, Buffer rx_buffer, int narg) {
-        (void)tx_buffer;
-        (void)rx_buffer;
-        printf("Reading DONE, event is %d\r\n", narg);
+    void compare_data_cb(v2::I2CTransaction *t, uint32_t narg) {
+        (void)t;
+        printf("Reading DONE, event is %lu\r\n", narg);
         // received buffer match with pattern
         int rc = memcmp(pattern, rx_data, sizeof(rx_data));
         if (rc == 0) {
-            printf("Read data match with written data, event is %d\r\n", narg);
+            printf("Read data match with written data, event is %lu\r\n", narg);
         } else {
-            printf("Read data doesn't match with written data, event is %d\r\n", narg);
-            for (int i = 0; i < sizeof(rx_data); i++) {
+            printf("Read data doesn't match with written data, event is %lu\r\n", narg);
+            for (uint32_t i = 0; i < sizeof(rx_data); i++) {
                 printf("Written:0x%x Read:0x%x \n\r", pattern[i], rx_data[i]);
             }
         }
@@ -117,7 +131,7 @@ private:
     }
 
 private:
-    I2C i2c;
+    v2::I2C i2c;
     char tx_data[buffer_size + 2];
     char rx_data[buffer_size];
 };


### PR DESCRIPTION
Modify the example to use the v1 I2C API.

Depends on https://github.com/ARMmbed/mbed-drivers/pull/102